### PR TITLE
fix: configure Jest to support modern syntax in react-redux

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,11 @@
   },
   "resolutions": {
     "nth-check": "2.0.1"
+  },
+  "jest": {
+    "transformIgnorePatterns": [
+      "node_modules/(?!(react-redux)/)"
+    ],
+    "testEnvironment": "jsdom"
   }
 }


### PR DESCRIPTION
### 📌 What’s Changed

- 🛠️ **Fixed Jest test failures** caused by unsupported modern JavaScript syntax (`??=`) in `react-redux`.
- ✅ Updated Jest configuration to properly transform `react-redux` by adjusting `transformIgnorePatterns` in `package.json`.

### 🧪 Testing

- Ran `npm test` and ensured all test suites now run without syntax errors.

### 📎 Notes

This fix allows us to use the latest version of `react-redux` with modern syntax while keeping our test environment stable.
